### PR TITLE
Bugfix: Append mode forces all writes to the end of the file

### DIFF
--- a/src/append_log.rs
+++ b/src/append_log.rs
@@ -177,10 +177,11 @@ impl<ResourceAdaptor: LoadStore> AppendLog<ResourceAdaptor> {
         }
         let mut file = OpenOptions::new()
             .read(true)
-            .append(true)
+            .write(true)
             .create(true)
             .open(out_file_path)
             .context(StdIoOpenError)?;
+        file.seek(SeekFrom::End(0)).context(StdIoSeekError)?;
         if file.stream_position().context(StdIoSeekError)? != self.write_pos {
             file.set_len(self.write_pos).context(StdIoWriteError)?;
             let _lines = file

--- a/src/fixed_append_log.rs
+++ b/src/fixed_append_log.rs
@@ -274,10 +274,11 @@ impl<ResourceAdaptor: LoadStore + Default> FixedAppendLog<ResourceAdaptor> {
         }
         let mut file = OpenOptions::new()
             .read(true)
-            .append(true)
+            .write(true)
             .create(true)
             .open(out_file_path)
             .context(StdIoOpenError)?;
+        file.seek(SeekFrom::End(0)).context(StdIoSeekError)?;
         if file.stream_position().context(StdIoSeekError)? != write_pos {
             file.set_len(write_pos).context(StdIoWriteError)?;
             let _lines = file

--- a/src/rolling_log.rs
+++ b/src/rolling_log.rs
@@ -136,10 +136,11 @@ impl<ResourceAdaptor: LoadStore> RollingLog<ResourceAdaptor> {
         }
         let mut file = OpenOptions::new()
             .read(true)
-            .append(true)
+            .write(true)
             .create(true)
             .open(out_file_path.clone())
             .context(StdIoOpenError)?;
+        file.seek(SeekFrom::End(0)).context(StdIoSeekError)?;
         self.file_entries = 0;
         if file.stream_position().context(StdIoSeekError)? == 0 {
             file.write_all(&[0u8; 4]).context(StdIoWriteError)?;


### PR DESCRIPTION
Opening a file in append mode makes all `writes` seek to the end of the file first. Not sure yet it fixes both issues.