### PR TITLE
Removed chrono, updated dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           args: -- -D warnings
 
       - name: Audit
-        run: cargo audit --ignore RUSTSEC-2020-0159
+        run: cargo audit
 
       - name: Build
         run: cargo build --release --examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ checksum = "6945cc5422176fc5e602e590c2878d2c2acd9a4fe20a4baa7c28022521698ec6"
 
 [[package]]
 name = "atomic_store"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ark-serialize",
  "array-init",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,6 @@ dependencies = [
  "ark-serialize",
  "array-init",
  "bincode",
- "chrono",
  "glob",
  "quickcheck",
  "quickcheck_macros",
@@ -80,9 +79,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
@@ -119,18 +118,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "winapi",
-]
 
 [[package]]
 name = "digest"
@@ -219,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "libm"
@@ -246,22 +233,11 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -276,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
@@ -291,9 +267,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -322,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -455,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atomic_store"
 description = "Persistence with atomic synchronization for a single version of record"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,6 @@ glob = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 
-[dependencies.chrono]
-version = "0.4"
-default-features = false
-features = ["clock"]
-
 [dev-dependencies]
 array-init = "2.0"
 quickcheck = "1.0"

--- a/src/append_log.rs
+++ b/src/append_log.rs
@@ -14,10 +14,10 @@ use crate::fixed_append_log;
 use crate::fixed_append_log::FixedAppendLog;
 use crate::load_store::{LoadStore, StorageLocationLoadStore};
 use crate::storage_location::{StorageLocation, STORAGE_LOCATION_SERIALIZED_SIZE};
+use crate::utils::unix_timestamp;
 use crate::version_sync::VersionSyncHandle;
 use crate::Result;
 
-use chrono::Utc;
 use snafu::ResultExt;
 
 use std::fs;
@@ -172,7 +172,7 @@ impl<ResourceAdaptor: LoadStore> AppendLog<ResourceAdaptor> {
                         "{}_{}.bak.{}",
                         self.file_pattern,
                         self.write_file_counter,
-                        Utc::now().timestamp()
+                        unix_timestamp()
                     ));
                     if self.write_pos > 0 {
                         fs::copy(&out_file_path, &backup_path).context(StdIoDirOpsSnafu)?;

--- a/src/atomic_store.rs
+++ b/src/atomic_store.rs
@@ -10,10 +10,10 @@ use crate::error::{
     StdIoDirOpsSnafu, StdIoOpenSnafu, StdIoReadSnafu, StdIoWriteSnafu,
 };
 use crate::storage_location::StorageLocation;
+use crate::utils::unix_timestamp;
 use crate::version_sync::VersionSyncHandle;
 use crate::Result;
 
-use chrono::Utc;
 use glob::glob;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
@@ -165,7 +165,7 @@ impl AtomicStoreLoader {
                 });
             }
             temp_path.push("temporary");
-            backup_path.push(format!("backup.{}", Utc::now().timestamp()));
+            backup_path.push(format!("backup.{}", unix_timestamp()));
 
             fs::rename(&storage_path, &temp_path).context(StdIoDirOpsSnafu)?;
             fs::create_dir(&storage_path).context(StdIoDirOpsSnafu)?;

--- a/src/fixed_append_log.rs
+++ b/src/fixed_append_log.rs
@@ -12,10 +12,10 @@ use crate::error::{
 };
 use crate::load_store::LoadStore;
 use crate::storage_location::StorageLocation;
+use crate::utils::unix_timestamp;
 use crate::version_sync::VersionSyncHandle;
 use crate::Result;
 
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
@@ -269,7 +269,7 @@ impl<ResourceAdaptor: LoadStore + Default> FixedAppendLog<ResourceAdaptor> {
                         self.file_pattern,
                         range_begin,
                         range_end,
-                        Utc::now().timestamp()
+                        unix_timestamp()
                     ));
                     if file_index > 0 {
                         fs::copy(&out_file_path, &backup_path).context(StdIoDirOpsSnafu)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 #[cfg(test)]
 mod testing;
 
+mod utils;
+
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck_macros;

--- a/src/rolling_log.rs
+++ b/src/rolling_log.rs
@@ -12,10 +12,10 @@ use crate::error::{
 };
 use crate::load_store::LoadStore;
 use crate::storage_location::StorageLocation;
+use crate::utils::unix_timestamp;
 use crate::version_sync::VersionSyncHandle;
 use crate::Result;
 
-use chrono::Utc;
 use snafu::ResultExt;
 
 use std::fs;
@@ -131,7 +131,7 @@ impl<ResourceAdaptor: LoadStore> RollingLog<ResourceAdaptor> {
                         "{}_{}.bak.{}",
                         self.file_pattern,
                         self.write_file_counter,
-                        Utc::now().timestamp()
+                        unix_timestamp()
                     ));
                     if self.write_pos > 0 {
                         fs::copy(&out_file_path, &backup_path).context(StdIoDirOpsSnafu)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,11 @@
+use std::time::SystemTime;
+
+/// Get the unix timestamp
+pub fn unix_timestamp() -> i64 {
+    match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(duration) => duration.as_secs() as i64,
+        // `duration_since` will error if `SystemTime::now()` is earlier than `UNIX_EPOCH`
+        // in that case, we just return the negative duration
+        Err(e) => -(e.duration().as_secs() as i64),
+    }
+}


### PR DESCRIPTION
We were only using `chrono` to get the current Utc timestamp since the unix epoch. This can be done with rust's std.

I've also:
- ran `cargo update`
- Removed the chrono CVE as chrono is no longer a dependency

On windows this calls [GetSystemTimePreciseAsFileTime](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime) or [GetSystemTimeAsFileTime](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimeasfiletime), both of which are UTC.

On linux this calls [clock_gettime (Realtime Clock)](https://linux.die.net/man/3/clock_gettime), which is the # of seconds since the unix epoch.

From this I can conclude this change shouldn't be affected by e.g. timezones and leap seconds.