### PR TITLE
Allow rolling log to prune old entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ struct ComponentPersistence {
 }
 
 impl ComponentPersistence {
-    pub fn new((store_path: &Path, key_tag: &str) -> Result<ComponentPersistence, PersistenceError> {
+    pub fn new(store_path: &Path, key_tag: &str) -> Result<ComponentPersistence, PersistenceError> {
         let mut loader = AtomicStoreLoader::load(&transform_path(store_path), key_tag)?;
         let type_x_tag = format!("{}_type_x", key_tag);
         let type_y_tag = format!("{}_type_y", key_tag);
@@ -43,11 +43,11 @@ impl ComponentPersistence {
             type_y_snapshots,
         })
     }
-    pub fn store_x((&mut self, x_element: &TypeX) {
+    pub fn store_x(&mut self, x_element: &TypeX) {
         self.type_x_array_history.store_resource(x_element).unwrap();
     }
 
-    pub fn store_y((&mut self, y_element: &TypeY) {
+    pub fn store_y(&mut self, y_element: &TypeY) {
         self.type_y_snapshots.store_resource(y_element).unwrap();
     }
 

--- a/src/rolling_log.rs
+++ b/src/rolling_log.rs
@@ -323,8 +323,7 @@ impl<ResourceAdaptor: LoadStore> RollingLog<ResourceAdaptor> {
             let mut file_index = commit_pos.file_counter;
             let mut retained_counter = self
                 .retained_entries
-                .checked_sub(commit_pos.store_length)
-                .unwrap_or(0);
+                .saturating_sub(commit_pos.store_length);
             loop {
                 if file_index == 0 {
                     break;
@@ -341,7 +340,7 @@ impl<ResourceAdaptor: LoadStore> RollingLog<ResourceAdaptor> {
                     let mut buffer = [0u8; 4];
                     read_file.read_exact(&mut buffer).context(StdIoReadSnafu)?;
                     let store_length = u32::from_le_bytes(buffer);
-                    retained_counter = retained_counter.checked_sub(store_length).unwrap_or(0);
+                    retained_counter = retained_counter.saturating_sub(store_length);
                 }
             }
         }

--- a/src/rolling_log.rs
+++ b/src/rolling_log.rs
@@ -321,7 +321,7 @@ impl<ResourceAdaptor: LoadStore> RollingLog<ResourceAdaptor> {
                 deleting = total_entries >= self.retained_entries;
             }
         }
-        return Ok(());
+        Ok(())
     }
 }
 


### PR DESCRIPTION
https://github.com/EspressoSystems/atomicstore/issues/27

Prunes rolling log value files when the number of entries exceeds the retained count